### PR TITLE
bij een beëindigd onderzoek moet nooit inOnderzoek worden geleverd...

### DIFF
--- a/features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.feature
@@ -209,17 +209,6 @@ Functionaliteit: persoon met 'indicatie vastgesteld verblijft niet op adres' bij
       En heeft de response een verblijfplaats voorkomen met de volgende gegevens
       | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
       | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
-      En heeft het verblijfplaats voorkomen de volgende 'inOnderzoek' gegevens
-      | naam                             | waarde      |
-      | adresseerbaarObjectIdentificatie | true        |
-      | datumVan                         | true        |
-      | functieAdres                     | true        |
-      | gemeenteVanInschrijving          | true        |
-      | nummeraanduidingIdentificatie    | true        |
-      | type                             | true        |
-      | datumIngangOnderzoek.type        | Datum       |
-      | datumIngangOnderzoek.datum       | 2023-05-16  |
-      | datumIngangOnderzoek.langFormaat | 16 mei 2023 |
       En heeft het verblijfplaats voorkomen de volgende 'verblijftNietOpAdresVanaf' gegevens
       | naam        | waarde      |
       | type        | Datum       |
@@ -230,26 +219,10 @@ Functionaliteit: persoon met 'indicatie vastgesteld verblijft niet op adres' bij
       | korteStraatnaam                              | Testpad     |
       | huisnummer                                   | 8           |
       | postcode                                     | 1234AB      |
-      | inOnderzoek.aanduidingBijHuisnummer          | true        |
-      | inOnderzoek.huisletter                       | true        |
-      | inOnderzoek.huisnummer                       | true        |
-      | inOnderzoek.huisnummertoevoeging             | true        |
-      | inOnderzoek.korteStraatnaam                  | true        |
-      | inOnderzoek.officieleStraatnaam              | true        |
-      | inOnderzoek.postcode                         | true        |
-      | inOnderzoek.woonplaats                       | true        |
-      | inOnderzoek.datumIngangOnderzoek.type        | Datum       |
-      | inOnderzoek.datumIngangOnderzoek.datum       | 2023-05-16  |
-      | inOnderzoek.datumIngangOnderzoek.langFormaat | 16 mei 2023 |
       En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
       | naam                                         | waarde                                 |
       | adresregel1                                  | Testpad 8                              |
       | adresregel2                                  | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
-      | inOnderzoek.adresregel1                      | true                                   |
-      | inOnderzoek.adresregel2                      | true                                   |
-      | inOnderzoek.datumIngangOnderzoek.type        | Datum                                  |
-      | inOnderzoek.datumIngangOnderzoek.datum       | 2023-05-16                             |
-      | inOnderzoek.datumIngangOnderzoek.langFormaat | 16 mei 2023                            |
 
       Voorbeelden:
       | aanduiding onderzoek | op of na | datum einde onderzoek |
@@ -274,17 +247,6 @@ Functionaliteit: persoon met 'indicatie vastgesteld verblijft niet op adres' bij
       Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
       | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
       | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
-      En heeft het verblijfplaats voorkomen de volgende 'inOnderzoek' gegevens
-      | naam                             | waarde      |
-      | adresseerbaarObjectIdentificatie | true        |
-      | datumVan                         | true        |
-      | functieAdres                     | true        |
-      | gemeenteVanInschrijving          | true        |
-      | nummeraanduidingIdentificatie    | true        |
-      | type                             | true        |
-      | datumIngangOnderzoek.type        | Datum       |
-      | datumIngangOnderzoek.datum       | 2023-05-16  |
-      | datumIngangOnderzoek.langFormaat | 16 mei 2023 |
       En heeft het verblijfplaats voorkomen de volgende 'verblijftNietOpAdresVanaf' gegevens
       | naam        | waarde      |
       | type        | Datum       |
@@ -295,26 +257,10 @@ Functionaliteit: persoon met 'indicatie vastgesteld verblijft niet op adres' bij
       | korteStraatnaam | Testpad |
       | huisnummer      | 8       |
       | postcode        | 1234AB  |
-      | inOnderzoek.aanduidingBijHuisnummer          | true        |
-      | inOnderzoek.huisletter                       | true        |
-      | inOnderzoek.huisnummer                       | true        |
-      | inOnderzoek.huisnummertoevoeging             | true        |
-      | inOnderzoek.korteStraatnaam                  | true        |
-      | inOnderzoek.officieleStraatnaam              | true        |
-      | inOnderzoek.postcode                         | true        |
-      | inOnderzoek.woonplaats                       | true        |
-      | inOnderzoek.datumIngangOnderzoek.type        | Datum       |
-      | inOnderzoek.datumIngangOnderzoek.datum       | 2023-05-16  |
-      | inOnderzoek.datumIngangOnderzoek.langFormaat | 16 mei 2023 |
       En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
       | naam        | waarde                                 |
       | adresregel1 | Testpad 8                              |
       | adresregel2 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
-      | inOnderzoek.adresregel1                      | true                                   |
-      | inOnderzoek.adresregel2                      | true                                   |
-      | inOnderzoek.datumIngangOnderzoek.type        | Datum                                  |
-      | inOnderzoek.datumIngangOnderzoek.datum       | 2023-05-16                             |
-      | inOnderzoek.datumIngangOnderzoek.langFormaat | 16 mei 2023                            |
 
       Voorbeelden:
       | aanduiding onderzoek | op of na | datum einde onderzoek |

--- a/src/Historie.Informatie.Service/Profiles/AdresVoorkomenProfile.cs
+++ b/src/Historie.Informatie.Service/Profiles/AdresVoorkomenProfile.cs
@@ -43,7 +43,7 @@ public class AdresVoorkomenProfile : Profile
 
                 if(src.InOnderzoek != null &&
                 new[] { "089999", "589999" }.Contains(src.InOnderzoek.AanduidingGegevensInOnderzoek) &&
-                dest.VerblijftNietOpAdresVanaf == null)
+                (dest.VerblijftNietOpAdresVanaf == null || src.InOnderzoek.DatumEindeOnderzoek != null))
                 {
                     dest.InOnderzoek = null;
                     dest.Verblijfadres.InOnderzoek = null;


### PR DESCRIPTION
...ook niet wanneer verblijftNietOpAdresVanaf wel wordt geleverd

@MelvLee dit onderzoek op een beëindigd onderzoek heb je toegevoegd aan de feature, maar ik ben het daar niet mee eens. Het onderzoek loopt niet meer en moet m.i. daarom niet met inOnderzoek worden getoond.